### PR TITLE
Protocol README: Fix bug in spec

### DIFF
--- a/proto/README
+++ b/proto/README
@@ -28,7 +28,7 @@ MPS7 transaction log specification:
 
 Header:
 
-| 4 byte magic string "MPS7" | 1 byte version | 4 byte (uint32) # of records |
+| 4 byte magic string "MPS7" | 1 byte version | 4 byte (uint32) # of records minus 1 |
 
 Record:
 


### PR DESCRIPTION
The "number of records" field is really the index of the last record when counting from zero, which is to say, the number of records minus one.
