### PR TITLE
Move notes back to COMMENTS file in git repo instead of homework app

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,15 @@ Submitting your completed homework
 
 To submit your homework, zip up the contents of your git repo in a .zip file.
 Please remove the .git directory, and anything else that might identify you.
-Then visit our [homework app](https://adhocteam.herokuapp.com/applicants/sign_up),
-sign up for an account, and follow the instructions to upload your homework there!
+If you want to include any comments with your submission, add them to the
+COMMENTS file. If there's anything important for us to know about how to run
+your code, please include that information in the COMMENTS file. We use Go,
+Ruby, and Python on a daily basis, so if your submission is in some other
+language (which is OK), please let us know how we can set up our environment
+to run your code. Feel free to include any other information relevant to your
+submission in the COMMENTS as well. Then visit our
+[homework app](https://adhocteam.herokuapp.com/applicants/sign_up), sign up
+for an account, and follow the instructions to upload your homework there!
 
 In addition to submitting the homework, make sure to complete the application for the job you're applying for on [our jobs page](https://www.adhocteam.us/join).
 


### PR DESCRIPTION
Depends on [adhoc_co #54](https://github.com/adhocteam/adhoc_co/pull/54)

Applicants will put their comments in a COMMENTS file as before.