### PR TITLE
Clarifications on a few problems

### DIFF
--- a/hhbuilder/README.md
+++ b/hhbuilder/README.md
@@ -11,7 +11,7 @@ Task
 You have been given an HTML page with a form and a placeholder for displaying
 a household.
 
-Write out JavaScript in the space provided that can:
+In the given index.html file, replace the "your code goes here" comment with JavaScript that can:
 
 * Validate data entry (age is required and > 0, relationship is required)
 * Add people to a growing household list
@@ -29,6 +29,9 @@ libraries -- i.e., no jQuery.
 
 The display of the household list is up to you.
 
-Put the serialized JSON in the provided "debug" DOM element.
+Put the serialized JSON in the provided "debug" DOM element and display that element on submission.
 
 Don't modify the initial HTML provided. (Obviously, you can modify the DOM.)
+
+The focus here is on the quality of your JavaScript, not the beauty of your design. The controls you add around viewing and deleting
+household members should be usable but need not be much to look at.

--- a/slcsp/README.md
+++ b/slcsp/README.md
@@ -20,11 +20,9 @@ Write your code in your best programming language.
 The order of the rows in your answer file must stay the same as how they
 appeared in the original `slcsp.csv`.
 
-If no SLCSP can be determined for a ZIP Code, leave the cell blank (no quotes or
-zeroes or other text).
-
 It may not be possible to determine a SLCSP for every ZIP Code given. Check for cases
-where a definitive answer cannot be found and leave those blank in the output CSV.
+where a definitive answer cannot be found and leave those cells blank in the output CSV (no
+quotes of zeroes or other text).
 
 Additional information
 ----------------------

--- a/slcsp/README.md
+++ b/slcsp/README.md
@@ -22,7 +22,7 @@ appeared in the original `slcsp.csv`.
 
 It may not be possible to determine a SLCSP for every ZIP Code given. Check for cases
 where a definitive answer cannot be found and leave those cells blank in the output CSV (no
-quotes of zeroes or other text).
+quotes or zeroes or other text).
 
 Additional information
 ----------------------

--- a/slcsp/README.md
+++ b/slcsp/README.md
@@ -23,14 +23,8 @@ appeared in the original `slcsp.csv`.
 If no SLCSP can be determined for a ZIP Code, leave the cell blank (no quotes or
 zeroes or other text).
 
-It may not be possible to determine a SLCSP for every ZIP Code given -- what
-reason or reasons are there? Fill in your explanation(s) below.
-
-    Reason:
-
-    1) ???
-
-    2) ???
+It may not be possible to determine a SLCSP for every ZIP Code given. Check for cases
+where a definitive answer cannot be found and leave those blank in the output CSV.
 
 Additional information
 ----------------------
@@ -58,3 +52,6 @@ There are two additional CSV files in this directory besides `slcsp.csv`:
 A ZIP Code can potentially be in more than one county. If the county can not be
 determined definitively by the ZIP Code, it may still be possible to determine
 the rate area for that ZIP Code.
+
+A ZIP Code can also be in more than one rate area. In that case, the answer is ambiguous
+and should be left blank.

--- a/slcsp/zips.csv
+++ b/slcsp/zips.csv
@@ -1,4 +1,4 @@
-zipcode,state,county,name,rate_area
+zipcode,state,county_code,name,rate_area
 36749,AL,01001,Autauga,11
 36703,AL,01001,Autauga,11
 36003,AL,01001,Autauga,11

--- a/slcsp/zips.csv
+++ b/slcsp/zips.csv
@@ -1,4 +1,4 @@
-zipcode,state,fips,name,rate_area
+zipcode,state,county,name,rate_area
 36749,AL,01001,Autauga,11
 36703,AL,01001,Autauga,11
 36003,AL,01001,Autauga,11


### PR DESCRIPTION
This is an attempt to address some of the questions we get in #public frequently, clarifying that:

* The javascript in hhbuilder should be inline with the HTML
* They should show the debug element in hhbuilder on submission (which makes life easier for us)
* That the beauty of the design in hhbuilder doesn't matter but the usability does
* Changes fips code in the slcsp CSV to county, since nobody knows what a FIPS code is

These may be controversial:

* Removes the question from the slcsp README, since nobody seems to fill it out.
* Indicates that in slcsp, if the zip code is in multiple rate areas then the answer is ambiguous. I feel like this is a trick where there's not an obviously correct answer, and it bums me out to call people incorrect for doing it the "wrong" way.