### PR TITLE
Remove reference to email

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ Getting help
 ------------
 
 If you get stuck, have a question, or want to clarify any aspect of the
-homework, you can contact members of our development team by:
-
- - emailing homework@adhocteam.us
- - joining our [public Slack channel](https://adhocteam-public.herokuapp.com)
+homework, you can contact members of our development team by
+joining our [public Slack channel.](https://adhocteam-public.herokuapp.com)
 
 We think a sign of a good developer is one who asks questions sooner, rather
 than later. We are happy to help guide you to the right solution.

--- a/proto/README.md
+++ b/proto/README.md
@@ -30,6 +30,8 @@ Header:
 
 | 4 byte magic string "MPS7" | 1 byte version | 4 byte (uint32) # of records |
 
+The header contains the canonical information about how the records should be processed.
+
 Record:
 
 | 1 byte record type enum | 4 byte (uint32) Unix timestamp | 8 byte (uint64) user ID |
@@ -45,5 +47,3 @@ For Debit and Credit record types, there is an additional field, an 8 byte
 (float64) amount in dollars, at the end of the record.
 
 All multi-byte fields are encoded in network byte order.
-
-The header contains the canonical information about how the records should be processed.


### PR DESCRIPTION
This removes the reference to email since we prefer candidates to use Slack. It also moves the comment I added yesterday in proto about the headers to a more appropriate place.