### PR TITLE
Provision: Remove the .vagrant directory

### DIFF
--- a/provision/provision.sh
+++ b/provision/provision.sh
@@ -2,6 +2,7 @@
 
 vagrant halt -f
 vagrant destroy -f
+rm -rf .vagrant
 vagrant up --provision
 
 # Check that status is 200 OK


### PR DESCRIPTION
There's a chance that submitted homework may have a `.vagrant` directory (even if the homework says not to include it. This could lead to errors trying to run the homework locally. To fix this, I added a force remove of the `.vagrant` directory right before doing an up.