### PR TITLE
SLCSP: Accurate csv headers

### DIFF
--- a/slcsp/plans.csv
+++ b/slcsp/plans.csv
@@ -1,4 +1,4 @@
-plan_id,state,metal_level,rate,rate_area
+plan_id,state,metal_level,rate,rate_number
 74449NR9870320,GA,Silver,298.62,7
 26325VH2723968,FL,Silver,421.43,60
 09846WB8636633,IL,Gold,361.69,5

--- a/slcsp/zips.csv
+++ b/slcsp/zips.csv
@@ -1,4 +1,4 @@
-zipcode,state,county_code,name,rate_area
+zipcode,state,county_code,name,rate_number
 36749,AL,01001,Autauga,11
 36703,AL,01001,Autauga,11
 36003,AL,01001,Autauga,11


### PR DESCRIPTION
(This is not my homework; this is me suggesting a change to an assignment.  I hope this is not obnoxious; I think this slight change would benefit future applicants.)

README.md states that "A rate area is a tuple of a state and a number, for example, NY 1, IL 14."  

These two CSV files use "rate_area" as the name of the final column, yet that column contains a number and not a tuple.  This number cannot be a unique id representing a tuple because each recurs across multiple states.

I believe, therefore, that the column name should be "rate_number" and not "rate_area" in order to align with all other information.  You might even go further and update the README.md to say, "A rate area is a tuple of a state and a rate number, for example, NY 1, IL 14." 