### PR TITLE
Update Centos to 7.4 - prevents vboxsf "No such device" error

### DIFF
--- a/provision/Vagrantfile
+++ b/provision/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/centos-6.8"
+  config.vm.box = "bento/centos-7.4"
 
   config.vm.network "private_network", type: "dhcp"
   config.vm.network "forwarded_port", guest: 80, host: 8080


### PR DESCRIPTION
When running `vagrant up` there is a vboxsf error:
```
➜  provision git:(master) vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'bento/centos-6.8' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Loading metadata for box 'bento/centos-6.8'
    default: URL: https://vagrantcloud.com/bento/centos-6.8
==> default: Adding box 'bento/centos-6.8' (v2.3.4) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/bento/boxes/centos-6.8/versions/2.3.4/providers/virtualbox.box
==> default: Successfully added box 'bento/centos-6.8' (v2.3.4) for 'virtualbox'!
==> default: Importing base box 'bento/centos-6.8'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'bento/centos-6.8' is up to date...
==> default: Setting the name of the VM: provision_default_1519877192000_15815
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 80 (guest) => 8080 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default:
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default:
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
[default] GuestAdditions versions on your host (5.1.30) and guest (5.1.18) do not match.
Loaded plugins: fastestmirror
Setting up Install Process
Determining fastest mirrors
 * base: mirror.vtti.vt.edu
 * extras: mirrors.sorengard.com
 * updates: linux.cc.lehigh.edu
No package kernel-devel-2.6.32-642.el6.x86_64 available.
Package 1:make-3.81-23.el6.x86_64 already installed and latest version
Package bzip2-1.0.5-7.el6_0.x86_64 already installed and latest version
Resolving Dependencies
--> Running transaction check
---> Package binutils.x86_64 0:2.20.51.0.2-5.44.el6 will be updated
---> Package binutils.x86_64 0:2.20.51.0.2-5.47.el6_9.1 will be an update
---> Package gcc.x86_64 0:4.4.7-18.el6 will be installed
--> Processing Dependency: libgomp = 4.4.7-18.el6 for package: gcc-4.4.7-18.el6.x86_64
--> Processing Dependency: cpp = 4.4.7-18.el6 for package: gcc-4.4.7-18.el6.x86_64
--> Processing Dependency: libgcc >= 4.4.7-18.el6 for package: gcc-4.4.7-18.el6.x86_64
--> Processing Dependency: glibc-devel >= 2.2.90-12 for package: gcc-4.4.7-18.el6.x86_64
---> Package perl.x86_64 4:5.10.1-141.el6_7.1 will be updated
--> Processing Dependency: perl = 4:5.10.1-141.el6_7.1 for package: 1:perl-Module-Pluggable-3.90-141.el6_7.1.x86_64
--> Processing Dependency: perl = 4:5.10.1-141.el6_7.1 for package: 4:perl-libs-5.10.1-141.el6_7.1.x86_64
--> Processing Dependency: perl = 4:5.10.1-141.el6_7.1 for package: 1:perl-Pod-Simple-3.13-141.el6_7.1.x86_64
--> Processing Dependency: perl = 4:5.10.1-141.el6_7.1 for package: 1:perl-Pod-Escapes-1.04-141.el6_7.1.x86_64
--> Processing Dependency: perl = 4:5.10.1-141.el6_7.1 for package: 3:perl-version-0.77-141.el6_7.1.x86_64
---> Package perl.x86_64 4:5.10.1-144.el6 will be an update
--> Running transaction check
---> Package cpp.x86_64 0:4.4.7-18.el6 will be installed
---> Package glibc-devel.x86_64 0:2.12-1.209.el6_9.2 will be installed
--> Processing Dependency: glibc-headers = 2.12-1.209.el6_9.2 for package: glibc-devel-2.12-1.209.el6_9.2.x86_64
--> Processing Dependency: glibc = 2.12-1.209.el6_9.2 for package: glibc-devel-2.12-1.209.el6_9.2.x86_64
--> Processing Dependency: glibc-headers for package: glibc-devel-2.12-1.209.el6_9.2.x86_64
---> Package libgcc.x86_64 0:4.4.7-17.el6 will be updated
---> Package libgcc.x86_64 0:4.4.7-18.el6 will be an update
---> Package libgomp.x86_64 0:4.4.7-17.el6 will be updated
---> Package libgomp.x86_64 0:4.4.7-18.el6 will be an update
---> Package perl-Module-Pluggable.x86_64 1:3.90-141.el6_7.1 will be updated
---> Package perl-Module-Pluggable.x86_64 1:3.90-144.el6 will be an update
---> Package perl-Pod-Escapes.x86_64 1:1.04-141.el6_7.1 will be updated
---> Package perl-Pod-Escapes.x86_64 1:1.04-144.el6 will be an update
---> Package perl-Pod-Simple.x86_64 1:3.13-141.el6_7.1 will be updated
---> Package perl-Pod-Simple.x86_64 1:3.13-144.el6 will be an update
---> Package perl-libs.x86_64 4:5.10.1-141.el6_7.1 will be updated
---> Package perl-libs.x86_64 4:5.10.1-144.el6 will be an update
---> Package perl-version.x86_64 3:0.77-141.el6_7.1 will be updated
---> Package perl-version.x86_64 3:0.77-144.el6 will be an update
--> Running transaction check
---> Package glibc.x86_64 0:2.12-1.192.el6 will be updated
--> Processing Dependency: glibc = 2.12-1.192.el6 for package: glibc-common-2.12-1.192.el6.x86_64
---> Package glibc.x86_64 0:2.12-1.209.el6_9.2 will be an update
---> Package glibc-headers.x86_64 0:2.12-1.209.el6_9.2 will be installed
--> Processing Dependency: kernel-headers >= 2.2.1 for package: glibc-headers-2.12-1.209.el6_9.2.x86_64
--> Processing Dependency: kernel-headers for package: glibc-headers-2.12-1.209.el6_9.2.x86_64
--> Running transaction check
---> Package glibc-common.x86_64 0:2.12-1.192.el6 will be updated
---> Package glibc-common.x86_64 0:2.12-1.209.el6_9.2 will be an update
---> Package kernel-headers.x86_64 0:2.6.32-696.20.1.el6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

================================================================================
 Package                 Arch     Version                       Repository
                                                                           Size
================================================================================
Installing:
 gcc                     x86_64   4.4.7-18.el6                  base       10 M
Updating:
 binutils                x86_64   2.20.51.0.2-5.47.el6_9.1      updates   2.8 M
 perl                    x86_64   4:5.10.1-144.el6              base       10 M
Installing for dependencies:
 cpp                     x86_64   4.4.7-18.el6                  base      3.7 M
 glibc-devel             x86_64   2.12-1.209.el6_9.2            updates   991 k
 glibc-headers           x86_64   2.12-1.209.el6_9.2            updates   620 k
 kernel-headers          x86_64   2.6.32-696.20.1.el6           updates   4.5 M
Updating for dependencies:
 glibc                   x86_64   2.12-1.209.el6_9.2            updates   3.8 M
 glibc-common            x86_64   2.12-1.209.el6_9.2            updates    14 M
 libgcc                  x86_64   4.4.7-18.el6                  base      103 k
 libgomp                 x86_64   4.4.7-18.el6                  base      134 k
 perl-Module-Pluggable   x86_64   1:3.90-144.el6                base       41 k
 perl-Pod-Escapes        x86_64   1:1.04-144.el6                base       33 k
 perl-Pod-Simple         x86_64   1:3.13-144.el6                base      213 k
 perl-libs               x86_64   4:5.10.1-144.el6              base      579 k
 perl-version            x86_64   3:0.77-144.el6                base       52 k

Transaction Summary
================================================================================
Install       5 Package(s)
Upgrade      11 Package(s)

Total download size: 52 M
Downloading Packages:
--------------------------------------------------------------------------------
Total                                           8.5 MB/s |  52 MB     00:06
warning: rpmts_HdrFromFdno: Header V3 RSA/SHA1 Signature, key ID c105b9de: NOKEY
Retrieving key from file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
Importing GPG key 0xC105B9DE:
 Userid : CentOS-6 Key (CentOS 6 Official Signing Key) <centos-6-key@centos.org>
 Package: centos-release-6-8.el6.centos.12.3.x86_64 (@anaconda-CentOS-201605220104.x86_64/6.8)
 From   : /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-6
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Updating   : libgcc-4.4.7-18.el6.x86_64                                  1/27
  Updating   : glibc-common-2.12-1.209.el6_9.2.x86_64                      2/27
  Updating   : glibc-2.12-1.209.el6_9.2.x86_64                             3/27
  Updating   : 1:perl-Pod-Escapes-1.04-144.el6.x86_64                      4/27
  Updating   : 4:perl-libs-5.10.1-144.el6.x86_64                           5/27
  Updating   : 1:perl-Pod-Simple-3.13-144.el6.x86_64                       6/27
  Updating   : 1:perl-Module-Pluggable-3.90-144.el6.x86_64                 7/27
  Updating   : 3:perl-version-0.77-144.el6.x86_64                          8/27
  Updating   : 4:perl-5.10.1-144.el6.x86_64                                9/27
  Updating   : binutils-2.20.51.0.2-5.47.el6_9.1.x86_64                   10/27
  Installing : cpp-4.4.7-18.el6.x86_64                                    11/27
  Updating   : libgomp-4.4.7-18.el6.x86_64                                12/27
  Installing : kernel-headers-2.6.32-696.20.1.el6.x86_64                  13/27
  Installing : glibc-headers-2.12-1.209.el6_9.2.x86_64                    14/27
  Installing : glibc-devel-2.12-1.209.el6_9.2.x86_64                      15/27
  Installing : gcc-4.4.7-18.el6.x86_64                                    16/27
  Cleanup    : 1:perl-Module-Pluggable-3.90-141.el6_7.1.x86_64            17/27
  Cleanup    : 1:perl-Pod-Escapes-1.04-141.el6_7.1.x86_64                 18/27
  Cleanup    : 1:perl-Pod-Simple-3.13-141.el6_7.1.x86_64                  19/27
  Cleanup    : 4:perl-libs-5.10.1-141.el6_7.1.x86_64                      20/27
  Cleanup    : 4:perl-5.10.1-141.el6_7.1.x86_64                           21/27
  Cleanup    : 3:perl-version-0.77-141.el6_7.1.x86_64                     22/27
  Cleanup    : libgomp-4.4.7-17.el6.x86_64                                23/27
  Cleanup    : binutils-2.20.51.0.2-5.44.el6.x86_64                       24/27
  Cleanup    : glibc-common-2.12-1.192.el6.x86_64                         25/27
  Cleanup    : glibc-2.12-1.192.el6.x86_64                                26/27
  Cleanup    : libgcc-4.4.7-17.el6.x86_64                                 27/27
  Verifying  : binutils-2.20.51.0.2-5.47.el6_9.1.x86_64                    1/27
  Verifying  : 3:perl-version-0.77-144.el6.x86_64                          2/27
  Verifying  : glibc-headers-2.12-1.209.el6_9.2.x86_64                     3/27
  Verifying  : 4:perl-5.10.1-144.el6.x86_64                                4/27
  Verifying  : kernel-headers-2.6.32-696.20.1.el6.x86_64                   5/27
  Verifying  : glibc-2.12-1.209.el6_9.2.x86_64                             6/27
  Verifying  : 4:perl-libs-5.10.1-144.el6.x86_64                           7/27
  Verifying  : glibc-devel-2.12-1.209.el6_9.2.x86_64                       8/27
  Verifying  : gcc-4.4.7-18.el6.x86_64                                     9/27
  Verifying  : 1:perl-Pod-Simple-3.13-144.el6.x86_64                      10/27
  Verifying  : 1:perl-Pod-Escapes-1.04-144.el6.x86_64                     11/27
  Verifying  : cpp-4.4.7-18.el6.x86_64                                    12/27
  Verifying  : glibc-common-2.12-1.209.el6_9.2.x86_64                     13/27
  Verifying  : libgcc-4.4.7-18.el6.x86_64                                 14/27
  Verifying  : 1:perl-Module-Pluggable-3.90-144.el6.x86_64                15/27
  Verifying  : libgomp-4.4.7-18.el6.x86_64                                16/27
  Verifying  : glibc-2.12-1.192.el6.x86_64                                17/27
  Verifying  : 1:perl-Module-Pluggable-3.90-141.el6_7.1.x86_64            18/27
  Verifying  : 4:perl-5.10.1-141.el6_7.1.x86_64                           19/27
  Verifying  : glibc-common-2.12-1.192.el6.x86_64                         20/27
  Verifying  : 1:perl-Pod-Simple-3.13-141.el6_7.1.x86_64                  21/27
  Verifying  : 1:perl-Pod-Escapes-1.04-141.el6_7.1.x86_64                 22/27
  Verifying  : libgcc-4.4.7-17.el6.x86_64                                 23/27
  Verifying  : binutils-2.20.51.0.2-5.44.el6.x86_64                       24/27
  Verifying  : 3:perl-version-0.77-141.el6_7.1.x86_64                     25/27
  Verifying  : 4:perl-libs-5.10.1-141.el6_7.1.x86_64                      26/27
  Verifying  : libgomp-4.4.7-17.el6.x86_64                                27/27

Installed:
  gcc.x86_64 0:4.4.7-18.el6

Dependency Installed:
  cpp.x86_64 0:4.4.7-18.el6
  glibc-devel.x86_64 0:2.12-1.209.el6_9.2
  glibc-headers.x86_64 0:2.12-1.209.el6_9.2
  kernel-headers.x86_64 0:2.6.32-696.20.1.el6

Updated:
  binutils.x86_64 0:2.20.51.0.2-5.47.el6_9.1    perl.x86_64 4:5.10.1-144.el6

Dependency Updated:
  glibc.x86_64 0:2.12-1.209.el6_9.2
  glibc-common.x86_64 0:2.12-1.209.el6_9.2
  libgcc.x86_64 0:4.4.7-18.el6
  libgomp.x86_64 0:4.4.7-18.el6
  perl-Module-Pluggable.x86_64 1:3.90-144.el6
  perl-Pod-Escapes.x86_64 1:1.04-144.el6
  perl-Pod-Simple.x86_64 1:3.13-144.el6
  perl-libs.x86_64 4:5.10.1-144.el6
  perl-version.x86_64 3:0.77-144.el6

Complete!
Downloading VirtualBox Guest Additions ISO from http://download.virtualbox.org/virtualbox/5.1.30/VBoxGuestAdditions_5.1.30.iso
Copy iso file /home/mchelen/.vagrant.d/tmp/VBoxGuestAdditions_5.1.30.iso into the box /tmp/VBoxGuestAdditions.iso
Mounting Virtualbox Guest Additions ISO to: /mnt
Installing Virtualbox Guest Additions 5.1.30 - guest version is 5.1.18
Verifying archive integrity... All good.
Uncompressing VirtualBox 5.1.30 Guest Additions for Linux...........
VirtualBox Guest Additions installer
Removing installed version 5.1.18 of VirtualBox Guest Additions...
vboxadd-service.sh: Stopping VirtualBox Guest Addition service.
vboxadd.sh: Stopping VirtualBox Additions.
Copying additional installer modules ...
Installing additional modules ...
vboxadd.sh: Starting the VirtualBox Guest Additions.
Failed to set up service vboxadd, please check the log file
/var/log/VBoxGuestAdditions.log for details.
An error occurred during installation of VirtualBox Guest Additions 5.1.30. Some functionality may not work as intended.
In most cases it is OK that the "Window System drivers" installation failed.
vboxadd.sh: Starting the VirtualBox Guest Additions.
vboxadd.sh: failed: Look at /var/log/vboxadd-install.log to find out what went wrong.
vboxadd.sh: failed: modprobe vboxguest failed.
vboxadd-service.sh: Starting VirtualBox Guest Addition service.
VirtualBox Additions module not loaded!
Unmounting Virtualbox Guest Additions ISO from: /mnt
Cleaning up downloaded VirtualBox Guest Additions ISO...
==> default: Checking for guest additions in VM...
==> default: [vagrant-hostsupdater] Checking for host entries
==> default: Configuring and enabling network interfaces...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
==> default: Mounting shared folders...
    default: /vagrant => /home/mchelen/tmp/homework/provision
Vagrant was unable to mount VirtualBox shared folders. This is usually
because the filesystem "vboxsf" is not available. This filesystem is
made available via the VirtualBox Guest Additions and kernel module.
Please verify that these guest additions are properly installed in the
guest. This is not a bug in Vagrant and is usually caused by a faulty
Vagrant box. For context, the command attempted was:

mount -t vboxsf -o uid=500,gid=500 vagrant /vagrant

The error output from the command was:

/sbin/mount.vboxsf: mounting failed with the error: No such device
```

```
[vagrant@localhost ~]$ cat /var/log/vboxadd-install.log
/tmp/vbox.0/Makefile.include.header:112: *** Error: unable to find the sources of your current Linux kernel. Specify KERN_DIR=<directory> and run Make again.  Stop.
Creating user for the Guest Additions.
Creating udev rule for the Guest Additions kernel module.
```
Fixed by upgrading Centos 6.8 to 7.4

This is probably due to presence of https://github.com/dotless-de/vagrant-vbguest

See also https://www.centos.org/forums/viewtopic.php?t=45163



Tested with:
Ubuntu 17.10
Virtualbox 5.1.30_Ubuntu r118389
Vagrant 2.0.2
vagrant-vbguest (0.15.1)



