### PR TITLE
Fix fetch error test

### DIFF
--- a/fetch/test/api/managed-record-test.js
+++ b/fetch/test/api/managed-record-test.js
@@ -88,7 +88,7 @@ describe("Records", function() {
       });
     }
 
-    retrieve().then(check);
+    retrieve().then(check).catch(done);
   });
 
 });


### PR DESCRIPTION
`retrieve` function call is expected to fail here, but never caught. It sends erroneous test results.
``` PhantomJS 2.1.1 (Mac OS X 0.0.0) Records should recover on fetch error FAILED
	Error: Timeout - Async callback was not invoked within timeout specified by jasmine.DEFAULT_TIMEOUT_INTERVAL. ```